### PR TITLE
extract_elf_ramdisk: Increase buffer for uncompressed ramdisks

### DIFF
--- a/extract_elf_ramdisk/extract_elf_ramdisk.c
+++ b/extract_elf_ramdisk/extract_elf_ramdisk.c
@@ -46,8 +46,8 @@
 #define EER_TMP_RAMDISK_CPIO "ramdisk.cpio" // temporary ramdisk cpio file name
 #define EER_SEARCH_STRING "fota-ua" // String to search to determine if the
                                     // ramdisk is a stock Sony FOTA ramdisk
-#define MEMORY_BUFFER_SIZE (const size_t)8192*1024 // Max size of uncompressed
-                                                   // ramdisk (8MB)
+#define MEMORY_BUFFER_SIZE (const size_t)20*1024*1024 // Max size of uncompressed
+                                                   // ramdisk (20 MB)
 #ifndef PATH_MAX
 #define PATH_MAX 255
 #endif


### PR DESCRIPTION
This fixes the following error (when the uncompressed ramdisk is bigger than 8mb):

gunzip error -- Err:inflate -5
Failed to gunzip

Use a bigger buffer (20 MB) to make sure this won't happen again.

Needed especially for TWRP(-based) recovery ramdisks (which are sometimes about ~12 MB big)

Change-Id: I59db6a8fff47876d4b4b535b24295484a98ab2ba
